### PR TITLE
Issue #9 - Add restaurant ownership checks when requesting meals and orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,7 @@ Restaurant owners can login to their dashboard to edit restaurant information, u
 
 [Video demo on YouTube](https://youtu.be/IzwRwoeHSOk)
 
-## Restaurant dashboard & backend
-[Restaurant dashboard link](http://swickapp.herokuapp.com)
-### Features
-* Create an account
-* View menu
-* Add and update meals with customizations and price additions
-* View current and past orders
-* Manage servers
-* View and update account information
+## Backend
 ### Technologies used
 * Python
 * Django
@@ -27,10 +19,24 @@ Restaurant owners can login to their dashboard to edit restaurant information, u
 * HTML/CSS/JavaScript
 * Bootstrap
 * jQuery
+### Restaurant dashboard features
+* [Restaurant dashboard link](http://swickapp.herokuapp.com)
+* Create an account
+* View menu
+* Add and update meals with customizations and price additions
+* View current and past orders
+* Manage servers
+* View and update account information
 
-## Customer App
-[Github link](https://github.com/seanlu99/SwickCustomerIOS)
-### Features
+## iOS Apps
+[Github link](https://github.com/swick-app/swick-ios)
+### Technologies used
+* Swift
+* Alamofire
+* SwiftyJSON
+* Facebook Login SDK
+* Stripe
+### Customer app features
 * Login through Facebook
 * Browse restaurants and menus
 * Scan QR code to link to restaurant and table
@@ -38,19 +44,8 @@ Restaurant owners can login to their dashboard to edit restaurant information, u
 * Search for restaurants, categories and meals
 * Pay through Stripe
 * View current and past orders
-### Technologies used
-* Swift
-* Alamofire
-* SwiftyJSON
-* Facebook Login SDK
-* Stripe
-
-## Server App
-[Github link](https://github.com/seanlu99/SwickServerIOS)
-### Features
+### Server app features
 * Login through Facebook
 * View orders to cook
 * View orders to send
 * View past orders
-### Technologies used
-Same as Customer App

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ chardet==3.0.4
 cryptography==2.9.2
 defusedxml==0.7.0rc1
 dj-database-url==0.5.0
-Django==3.0.6
+Django==3.0.7
 django-bootstrap3==12.1.0
 django-braces==1.14.0
 django-oauth-toolkit==1.3.2


### PR DESCRIPTION
Added checks to make sure 'request.user.restaurant' is equivalent to 'meal.restaurant' or 'order.restaurant' depending on the requested 'id'. A 404 page is thrown upon check failure. 